### PR TITLE
Less destructive way of updating control version

### DIFF
--- a/Controls/Deployment/package.ps1
+++ b/Controls/Deployment/package.ps1
@@ -1,13 +1,18 @@
 function New-PCFControlVersion($manifestFilePath){
-    $pattern = 'version="(\d+\.)?(\d+\.)?(\*|\d+)" display-name-key'
+    # Read in XML file
+    $xml = [xml](Get-Content $manifestFilePath)
+    
+    # Get current control version
+    $controlVersion = [version]$xml.SelectSingleNode("/manifest/control").version
+    
+    # Build the new control version (increment build number only)
+    $newControlVersion = "{0}.{1}.{2}" -f $controlVersion.Major, $controlVersion.Minor, ($controlVersion.Build + 1)
+    
+    # Set the new control version
+    $xml.SelectSingleNode("/manifest/control").version = $newControlVersion
 
-	$V = Select-String -Path $manifestFilePath -Pattern $pattern
-	$currentVersion = [int]$V.Matches[0].Groups[3].Value
-	$nextVersion =  [int]$V.Matches[0].Groups[3].Value + 1
-
-	$fileContent = Get-Content $manifestFilePath
-	$fileContent = $fileContent.replace("$currentVersion`"",  "$nextVersion`"") 
-	Set-Content -Path $manifestFilePath -value $fileContent
+    # Save the updated XML
+    $xml.Save($manifestFilePath)
 }
 
 


### PR DESCRIPTION
Previously, `New-PCFControlVersion` would increase any found occurences of the build number where the build number was followed by a quote symbol. 

Test 1
Assuming an initial build number of 1 and a resource with an `order` of 1. Upon running `New-PCFControlVersion`, the control build number would be increased to 2, as would the resources order. This is because the resources order is followed by a quote.

Test 2
- Start a new PCF project
- Run `New-PCFControlVersion` 7 time on the manifest file
- On the 8th run, note the `encoding` attribute of the `xml` node it changed to 'UTF-9', rendering the file invalid

The proposed way uses the `xml` and `version` types for a more readible and reliable approach.